### PR TITLE
fix workflow for pushing images w/no pr creation

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -99,34 +99,41 @@ jobs:
             echo "Updated ${deployment} with new image tag ${new_hash}"
           done
 
+      - name: Check if any files were changed
+        if: ${{ env.IMAGE_TAG }}
+        run: echo "CHANGED_FILES=$(git status --porcelain -uno | awk '{print $2}')" >> $GITHUB_ENV
+
       - name: Create feature branch, add, commit, push changes and open a pull request
         if: ${{ env.IMAGE_TAG }}
         env:
           GH_TOKEN: ${{ secrets.IMAGE_BUILDER_CREATE_PR }}
         run: |
-          CHANGED_FILES=$(git status --porcelain -uno | awk '{print $2}')
-          git diff
-          git checkout -b update-${HUB}-image-tag-${IMAGE_TAG}
-          # to be safe, only add files that have changed
-          for file in $(echo -e ${CHANGED_FILES}); do
-            git add ${file}
-          done
+          if [[ -n "${{ env.CHANGED_FILES }}" ]]; then
+            echo "Files changed: ${{ env.CHANGED_FILES }}"
+            git diff
+            git checkout -b update-${HUB}-image-tag-${IMAGE_TAG}
+            # to be safe, only add files that have changed
+            for file in $(echo -e ${{ env.CHANGED_FILES }}); do
+              git add ${file}
+            done
 
-          BRANCH="update-${HUB}-image-tag-${IMAGE_TAG}"
-          MESSAGE="update ${HUB} image tag to ${IMAGE_TAG}"
-          git commit -m "${MESSAGE}"
-          git push origin ${BRANCH}
-          #
-          # now create a PR!
-          #
-          cat << EOF > ${HOME}/pr-body.txt
-          ${MESSAGE}
+            BRANCH="update-${HUB}-image-tag-${IMAGE_TAG}"
+            MESSAGE="update ${HUB} image tag to ${IMAGE_TAG}"
+            git commit -m "${MESSAGE}"
+            git push origin ${BRANCH}
+            #
+            # now create a PR!
+            #
+            cat << EOF > ${HOME}/pr-body.txt
+            ${MESSAGE}
 
-          ${CHANGED_FILES}
-          EOF
-          BODY=$(cat ${HOME}/pr-body.txt)
-          gh pr new -t "${MESSAGE}" -b "${BODY}" -H${BRANCH} -Bstaging
-
+            ${{ env.CHANGED_FILES }}
+            EOF
+            BODY=$(cat ${HOME}/pr-body.txt)
+            gh pr new -t "${MESSAGE}" -b "${BODY}" -H${BRANCH} -Bstaging
+          else
+            echo "No files changed, no PR created."
+          fi
       - name: Print out a message if no PR is created
         if: ${{ ! env.IMAGE_TAG }}
         run: |

--- a/apt.txt
+++ b/apt.txt
@@ -9,9 +9,8 @@ curl
 wget
 vim
 
-# for easily managing multiple repositories with one command (perl-doc
-# is needed for its help pages to work)
-mr
+# other important things
+htop
 perl-doc
 
 # Regular build tools for compiling common stuff


### PR DESCRIPTION
when an image isn't deployed, the PR creation step shouldn't fail