### PR TITLE
bump code-server

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - pip==25.1.1
 
   # vscode
-  - code-server==4.106.2
+  - code-server==4.106.3
   - jupyter-vscode-proxy==0.7
   - jupyter-server-proxy==4.4.0
 


### PR DESCRIPTION
i'm bumping code-server to the latest version, maybe this will stop vscode from OOMKilling the user pod when 2 sessions are opened...

if that fails, i'll try removing the vscode java packages and see if that helps