### PR TITLE
bump jupyterlab to 4.5.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - ipython==9.7.0
   - jupyter-resource-usage=1.2.0
   - jupyterhub==5.4.3
-  - jupyterlab==4.5.2
+  - jupyterlab==4.5.8
   - jupyter-archive==3.4.0
   - jupyter_server==2.16.0
   - jupyterlab-git==0.51.2


### PR DESCRIPTION
Bumps jupyterlab to 4.5.8.

Tested via repo2docker --no-run on base-python-image — build passed clean.

Generated with Claude Code